### PR TITLE
Add mnemonic for Italian card

### DIFF
--- a/language/decks/italian.yaml
+++ b/language/decks/italian.yaml
@@ -1,6 +1,7 @@
 - id: 5001
-  front: After
-  back: Dietro
+  front: Dietro
+  back: behind / after
+  mnemonic: I dive in, feel the icy sensation (5000), see bright DAY (1) light, then a huge D-retro surfboard bumps me from behind.
 - id: 5002
   front: Again
   back: Di nuovo


### PR DESCRIPTION
## Summary
- update `italian.yaml` so card `5001` shows the Italian word on the front
- add mnemonic text to provide a helpful memory cue

## Testing
- `python - <<'PY'
import sys, os
import codecs
p='language/decks/italian.yaml'
with open(p, 'rb') as f:
    data=f.read()
print('endswith newline?', data.endswith(b'\n'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_685e9e895320832fbc562e86df2a6a17